### PR TITLE
fix wrong example for mutt query_command

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -81,7 +81,7 @@ that query_command uses pc_query:
 
 Example from .muttrc::
 
-        set query_command="/home/username/bin/pc_query -m '%s'"
+        set query_command="/home/username/bin/pc_query -m %s"
 
 The current version features experimental write support. If you want to
 test this, first make sure **you have a backup of your data** (but please do

--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -20,7 +20,7 @@ that query_command uses pc_query:
 
 Example from .muttrc::
 
-        set query_command="/home/username/bin/pc_query -m '%s'"
+        set query_command="/home/username/bin/pc_query -m %s"
 
 The current version features experimental write support. If you want to
 test this, first make sure **you have a backup of your data** (but please do


### PR DESCRIPTION
from the muttrc manpage:

Mutt will add quotes around the string substituted for “%s”  automatically  according  to  shell  quoting rules, so you should avoid adding yourown.

and in case you search for

<some where>TAB

you will get an: To: <some where>sh: 1: cannot open some: No such file
